### PR TITLE
adding examples for showing up in RTD. 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio", "terminalio"]
+autodoc_mock_imports = ["displayio", "terminalio", "adafruit_display_text"]
 
 autodoc_preserve_defaults = True
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,31 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/displayio_listselect_simpletest.py
     :caption: examples/displayio_listselect_simpletest.py
     :linenos:
+
+FunHouse example for ListSelect
+--------------------------------
+
+FunHouse example for ListSelect
+
+.. literalinclude:: ../examples/displayio_listselect_funhouse_test.py
+    :caption: examples/displayio_listselect_funhouse_test.py
+    :linenos:
+
+Joystick example for ListSelect
+--------------------------------
+
+Joystick example for ListSelect
+
+.. literalinclude:: ../examples/displayio_listselect_joystick.py
+    :caption: examples/displayio_listselect_joystick.py
+    :linenos:
+
+PyGame example for ListSelect
+--------------------------------
+
+Runs on a PC / RasPi in CPython using Blinka_DisplayIO and PyGameDisplay
+
+
+.. literalinclude:: ../examples/displayio_listselect_pygamedisplay_simpletest.py
+    :caption: examples/displayio_listselect_pygamedisplay_simpletest.py
+    :linenos:

--- a/examples/displayio_listselect_joystick.py
+++ b/examples/displayio_listselect_joystick.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 """
-FunHouse example for ListSelect
+Joystick example for ListSelect
 Make a ListSelect and use up, down, and select buttons to interact with it.
 """
 import time


### PR DESCRIPTION
Also add adafruit_text_display to the conf.py to make the docs building happy. Correcting an example description in preparation for a new PR.